### PR TITLE
refactor the parsing of the personality response by renaming variables and restructuring the looping for clarity

### DIFF
--- a/routes/watson.js
+++ b/routes/watson.js
@@ -91,9 +91,7 @@ function parsePersonalityResponse(response) {
   // This may change in the future.
   const aspects = response.tree.children;
 
-  for (let i = 0; i < aspects.length; i++) {
-    const aspect = aspects[i];
-
+  aspects.forEach(aspect => {
     // loop for traits of aspects
     aspect.children.forEach(trait => {
       const traitObject = { id: trait.id, percentage: trait.percentage };
@@ -105,8 +103,8 @@ function parsePersonalityResponse(response) {
         resultArray.push(subTraitObject);
       });
     });
-  }
-
+  });
+  
   return resultArray;
 }
 


### PR DESCRIPTION
In order to re-factor the parsing of a response, I re-named the variables to more descriptive names.

As per the comments, there are children detected in the response's tree property right now. I can separate these for clarity but that might change depending on changes to the API.

Please take a look. :)