### PR TITLE
Feature add google analytics

### DIFF
--- a/public/analytics/analytics.js
+++ b/public/analytics/analytics.js
@@ -1,5 +1,0 @@
-(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-K7W4383');

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -1,8 +1,12 @@
 doctype html
 html
   head
-
-    script(src='/analytics/analytics.js')
+    script.
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-K7W4383');
 
     title=title
 


### PR DESCRIPTION
The purpose of this PR is to add Google Analytics to the O3-Barista app at [https://o3-barista.herokuapp.com/](http://o3-moods.herokuapp.com/). I set up an O3 Labs account, made a property ID for O3-Barista, and added the GA tags generated in Tad Manager to the head and body elements.

I could not just add the tag to a pug file so I created an analytics folder in public and referenced the tag in a script tag in the layout pug file.

Please take a look. :)